### PR TITLE
docs: clarify agent POC description

### DIFF
--- a/agents/agents-pocs.md
+++ b/agents/agents-pocs.md
@@ -191,7 +191,7 @@ https://github.com/diegopacheco/ai-playground/tree/main/pocs/anti-gravity-cli-fu
 
 ### POCs: AI Agents
 
-This pocs I built AI Agents that run in the background wither by a trigger or autonomus using APIs(OpenAI/Anthropic).
+These POCs are AI agents that run in the background, either by a trigger or autonomously using APIs (OpenAI/Anthropic).
 
 1 - Smith: Scala Security Agent <br/>
 https://github.com/diegopacheco/Smith <br/>


### PR DESCRIPTION
Clarifies the opening description for the AI agent POCs and fixes the `wither`/`autonomus` wording.