### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #11)

### DIFF
--- a/pocs/agent-skill-linter/skill/commands/lint-site.md
+++ b/pocs/agent-skill-linter/skill/commands/lint-site.md
@@ -1,6 +1,6 @@
 ---
 description: Render the latest lint report as a modern web report in Podman
-argument-hint: [path]
+argument-hint: "[path]"
 ---
 
 Render the lint report for the codebase at `$ARGUMENTS` (default: current working

--- a/pocs/agent-skill-linter/skill/commands/lint.md
+++ b/pocs/agent-skill-linter/skill/commands/lint.md
@@ -1,6 +1,6 @@
 ---
 description: Lint the target codebase and write .lint/report.json plus a history entry
-argument-hint: [path]
+argument-hint: "[path]"
 ---
 
 Lint the codebase at `$ARGUMENTS` (default: the current working directory). Steps:

--- a/pocs/coding-agent-gsd/.claude/commands/gsd/add-todo.md
+++ b/pocs/coding-agent-gsd/.claude/commands/gsd/add-todo.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:add-todo
 description: Capture idea or task as todo from current conversation context
-argument-hint: [optional description]
+argument-hint: "[optional description]"
 allowed-tools:
   - Read
   - Write

--- a/pocs/coding-agent-gsd/.claude/commands/gsd/check-todos.md
+++ b/pocs/coding-agent-gsd/.claude/commands/gsd/check-todos.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:check-todos
 description: List pending todos and select one to work on
-argument-hint: [area filter]
+argument-hint: "[area filter]"
 allowed-tools:
   - Read
   - Write

--- a/pocs/coding-agent-gsd/.claude/commands/gsd/debug.md
+++ b/pocs/coding-agent-gsd/.claude/commands/gsd/debug.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [issue description]
+argument-hint: "[issue description]"
 allowed-tools:
   - Read
   - Bash


### PR DESCRIPTION
Closes #11.

## Summary

Purely mechanical single-character transform to 5 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (5)

- `pocs/agent-skill-linter/skill/commands/lint.md`
- `pocs/coding-agent-gsd/.claude/commands/gsd/debug.md`
- `pocs/coding-agent-gsd/.claude/commands/gsd/add-todo.md`
- `pocs/coding-agent-gsd/.claude/commands/gsd/check-todos.md`
- `pocs/agent-skill-linter/skill/commands/lint-site.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
